### PR TITLE
Fix typo in ovpn_genconfig

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -329,7 +329,7 @@ key-direction 0
 keepalive $OVPN_KEEPALIVE
 persist-key
 persist-tun
-duplicate_cn
+duplicate-cn
 
 proto $OVPN_PROTO
 # Rely on Docker to do port mapping, internally always 1194


### PR DESCRIPTION
The generated configuration contains a typo which prevents the server from starting.